### PR TITLE
enrol_auto: Avoid accessing a variable which may not have been defined

### DIFF
--- a/classes/observer.php
+++ b/classes/observer.php
@@ -54,8 +54,8 @@ class observer {
 
         $autoplugin = enrol_get_plugin('auto');
 
-        if ((!$instance = $autoplugin->get_instance_for_course($eventdata['courseid']))
-                || $instance->status == ENROL_INSTANCE_DISABLED) {
+        if (!($instance = $autoplugin->get_instance_for_course($eventdata['courseid'])
+                && $instance->status == ENROL_INSTANCE_ENABLED)) {
             return;
         }
 


### PR DESCRIPTION
As it stands, if the first part of the condition returns false, $instance will never be defined, so the second part will just produce an error.